### PR TITLE
chore: improvements and cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,11 @@ dependencies = [
  "const_format",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-controllers",
  "cw-multi-test",
  "cw-storage-plus",
  "cw-utils",
+ "cw2",
  "manifest-std",
  "prost",
  "serde",
@@ -452,6 +454,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-controllers"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8b9a060524f8c5bff8c736e890fb52a16533e7107c6c41e1cae6077c177516"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw-utils",
+ "schemars 0.8.22",
+ "serde",
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "cw-multi-test"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +535,21 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "schemars 0.8.22",
+ "serde",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "cw2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50582114ab739724c25a27cea1785351f2b5fea7968214302e0023ee2c0e8b39"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "schemars 0.8.22",
+ "semver",
  "serde",
  "thiserror 2.0.16",
 ]

--- a/converter/Cargo.toml
+++ b/converter/Cargo.toml
@@ -14,6 +14,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 bech32 = "0.11.0"
 const_format = "0.2"
+cw2 = "3"
+cw-controllers = "3"
 prost = "0.14.1"
 cosmwasm-std = { version = "3", features = ["cosmwasm_2_2"] }
 cosmwasm-schema = "3"

--- a/converter/src/consts.rs
+++ b/converter/src/consts.rs
@@ -1,9 +1,15 @@
 use crate::denom::Denom;
 use const_format::formatcp;
 
+pub const CONTRACT_NAME: &str = "manifest/converter";
+
+pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub const BECH32_PREFIX: &str = "manifest";
+
 // The default POA admin address of the Manifest Network
 pub const DEFAULT_POA_ADMIN: &str =
-    "manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj";
+    formatcp!("{BECH32_PREFIX}1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj");
 
 // The default base denom of the Manifest Network
 pub const DEFAULT_SOURCE_DENOM: &str = "umfx";

--- a/converter/src/contract.rs
+++ b/converter/src/contract.rs
@@ -94,17 +94,6 @@ pub fn migrate(
         .add_attribute("to_version", CONTRACT_VERSION))
 }
 
-mod helper {
-    pub(crate) fn to_manifest_coin(
-        c: &cosmwasm_std::Coin,
-    ) -> manifest_std::cosmos::base::v1beta1::Coin {
-        manifest_std::cosmos::base::v1beta1::Coin {
-            denom: c.denom.clone(),
-            amount: c.amount.to_string(),
-        }
-    }
-}
-
 mod query {
     use super::*;
 
@@ -253,7 +242,10 @@ mod exec {
         // Prepare to burn the tokens from the POA's held balance
         let burn = MsgBurnHeldBalance {
             authority: config.poa_admin.to_string(),
-            burn_coins: vec![helper::to_manifest_coin(&coin)],
+            burn_coins: vec![manifest_std::cosmos::base::v1beta1::Coin {
+                denom: config.source_denom.to_string(),
+                amount: coin.amount.to_string(),
+            }],
         };
         let any_burn = Any {
             type_url: MsgBurnHeldBalance::TYPE_URL.to_string(),

--- a/converter/src/contract.rs
+++ b/converter/src/contract.rs
@@ -1,25 +1,54 @@
+use crate::consts::{CONTRACT_NAME, CONTRACT_VERSION};
+use crate::error::AmountError::NonPayable;
+use crate::error::ConfigError::SameDenom;
 use crate::error::ContractError;
-use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::state::CONFIG;
-use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use crate::error::MigrateError::InvalidContractName;
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use crate::state::{Config, ADMIN, CONFIG};
+use cosmwasm_std::{
+    to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, MigrateInfo, Response, StdResult,
+};
+use cw2::{get_contract_version, set_contract_version};
+use cw_utils::nonpayable;
 
 pub fn instantiate(
     deps: DepsMut,
     _env: Env,
-    _info: MessageInfo,
+    info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
-    deps.api.addr_validate(msg.config.admin.as_str())?;
-    CONFIG.save(deps.storage, &msg.config)?;
+    nonpayable(&info).map_err(|_| ContractError::AmountError(NonPayable))?;
+    let admin = deps.api.addr_validate(msg.admin.as_str())?;
 
-    Ok(Response::new())
+    // Rate is validated in its constructor
+    // Denoms are validated in their constructors
+
+    if msg.source_denom == msg.target_denom {
+        return Err(ContractError::ConfigError(SameDenom));
+    }
+
+    let config = Config {
+        poa_admin: deps.api.addr_validate(msg.poa_admin.as_str())?,
+        rate: crate::rate::Rate::parse(&msg.rate)?,
+        source_denom: crate::denom::Denom::new(msg.source_denom)?,
+        target_denom: crate::denom::Denom::new(msg.target_denom)?,
+        paused: msg.paused,
+    };
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    CONFIG.save(deps.storage, &config)?;
+    ADMIN.set(deps, Some(admin))?;
+
+    Ok(Response::new().add_attribute("action", "instantiate"))
 }
 
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     use QueryMsg::*;
 
     match msg {
-        Config {} => to_json_binary(&query::config(deps)?),
+        Config {} => query::config(deps),
+        Admin {} => query::admin(deps),
     }
 }
 
@@ -31,9 +60,41 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     use ExecuteMsg::*;
     match msg {
+        UpdateAdmin { admin } => exec::update_admin(deps, info, admin),
         UpdateConfig { config } => exec::update_config(deps, info, config),
-        Convert {} => exec::convert(deps, env, info),
+        Convert {} => exec::convert(deps.as_ref(), env, info),
     }
+}
+
+pub fn migrate(
+    deps: DepsMut,
+    _env: Env,
+    _msg: MigrateMsg,
+    _info: MigrateInfo,
+) -> Result<Response, ContractError> {
+    let stored = get_contract_version(deps.storage)?;
+
+    if stored.contract != CONTRACT_NAME {
+        return Err(ContractError::MigrateError(InvalidContractName));
+    }
+
+    if stored.version == CONTRACT_VERSION {
+        return Ok(Response::new()
+            .add_attribute("action", "migrate")
+            .add_attribute("note", "already at latest version")
+            .add_attribute("version", CONTRACT_VERSION));
+    }
+
+    // TODO: Add migration steps when needed
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    Ok(Response::new().add_attributes([
+        ("action", "migrate"),
+        ("contract", CONTRACT_NAME),
+        ("from_version", stored.version.as_str()),
+        ("to_version", CONTRACT_VERSION),
+    ]))
 }
 
 mod helper {
@@ -41,7 +102,7 @@ mod helper {
         c: &cosmwasm_std::Coin,
     ) -> manifest_std::cosmos::base::v1beta1::Coin {
         manifest_std::cosmos::base::v1beta1::Coin {
-            denom: c.denom.to_string(),
+            denom: c.denom.clone(),
             amount: c.amount.to_string(),
         }
     }
@@ -49,23 +110,25 @@ mod helper {
 
 mod query {
     use super::*;
-    use crate::msg::ConfigResp;
 
-    pub fn config(deps: Deps) -> StdResult<ConfigResp> {
-        let config = CONFIG.load(deps.storage)?;
-        Ok(ConfigResp { config })
+    pub fn config(deps: Deps) -> StdResult<Binary> {
+        to_json_binary(&CONFIG.load(deps.storage)?)
+    }
+
+    pub fn admin(deps: Deps) -> StdResult<Binary> {
+        to_json_binary(&ADMIN.query_admin(deps)?)
     }
 }
 
 mod exec {
     use super::*;
     use crate::denom::Denom;
-    use crate::error::AuthError;
-    use crate::error::ConfigError::SameDenom;
+    use crate::error::AmountError::AmountIsZero;
+    use crate::error::AuthError::NotAdmin;
     use crate::error::ConvertError::{InvalidFunds, InvalidSourceDenom};
     use crate::msg::UpdateConfig;
     use crate::rate::Rate;
-    use cosmwasm_std::{AnyMsg, BankMsg, CosmosMsg};
+    use cosmwasm_std::{AnyMsg, BankMsg, CosmosMsg, StdError};
     use cw_utils::one_coin;
     use manifest_std::cosmos::authz::v1beta1::MsgExec;
     use manifest_std::google::protobuf::Any;
@@ -73,30 +136,52 @@ mod exec {
     use manifest_std::osmosis::tokenfactory::v1beta1::MsgMint;
     use prost::Message;
 
+    pub fn update_admin(
+        deps: DepsMut,
+        info: MessageInfo,
+        admin: Option<String>,
+    ) -> Result<Response, ContractError> {
+        nonpayable(&info).map_err(|_| ContractError::AmountError(NonPayable))?;
+        let new = match &admin {
+            Some(a) => Some(deps.api.addr_validate(a)?),
+            None => None,
+        };
+        let res = ADMIN
+            .execute_update_admin(deps, info, new)
+            .map_err(|e| ContractError::StdError(StdError::from(e)))?;
+        Ok(res
+            .add_attribute("action", "update_admin")
+            .add_attribute("contract", CONTRACT_NAME)
+            .add_attribute("version", CONTRACT_VERSION)
+            .add_attribute("new_admin", admin.as_deref().unwrap_or("none")))
+    }
+
     // Update the contract configuration with new values
     pub fn update_config(
         deps: DepsMut,
         info: MessageInfo,
         config: UpdateConfig,
     ) -> Result<Response, ContractError> {
+        nonpayable(&info).map_err(|_| ContractError::AmountError(NonPayable))?;
+        ADMIN
+            .assert_admin(deps.as_ref(), &info.sender)
+            .map_err(|_| ContractError::Unauthorized(NotAdmin))?;
+
         if config.is_empty() {
             return Ok(Response::new()
                 .add_attribute("action", "update_config")
-                .add_attribute("note", "no changes made"));
+                .add_attribute("note", "empty config, no changes made"));
         }
         let mut current_config = CONFIG.load(deps.storage)?;
 
-        if info.sender != current_config.admin {
-            return Err(ContractError::Unauthorized(AuthError::NotAdmin));
-        }
-
-        if let Some(admin) = config.admin {
-            let admin_addr = deps.api.addr_validate(admin.as_str())?;
-            current_config.admin = admin_addr;
+        if config.is_noop(&current_config) {
+            return Ok(Response::new()
+                .add_attribute("action", "update_config")
+                .add_attribute("note", "identical config, no changes made"));
         }
 
         if let Some(poa_admin) = config.poa_admin {
-            let poa_admin_addr = deps.api.addr_validate(poa_admin.as_str())?;
+            let poa_admin_addr = deps.api.addr_validate(&poa_admin)?;
             current_config.poa_admin = poa_admin_addr;
         }
 
@@ -112,6 +197,10 @@ mod exec {
             current_config.target_denom = Denom::new(target_denom)?;
         }
 
+        if let Some(paused) = config.paused {
+            current_config.paused = paused;
+        }
+
         // Ensure source and target denoms are not the same
         if current_config.source_denom == current_config.target_denom {
             return Err(ContractError::ConfigError(SameDenom));
@@ -119,13 +208,16 @@ mod exec {
 
         CONFIG.save(deps.storage, &current_config)?;
 
-        Ok(Response::new()
-            .add_attribute("action", "update_config")
-            .add_attribute("admin", current_config.admin.into_string())
-            .add_attribute("poa_admin", current_config.poa_admin.into_string())
-            .add_attribute("rate", current_config.rate.to_string())
-            .add_attribute("source_denom", current_config.source_denom)
-            .add_attribute("target_denom", current_config.target_denom))
+        Ok(Response::new().add_attributes([
+            ("action", "update_config"),
+            ("contract", CONTRACT_NAME),
+            ("version", CONTRACT_VERSION),
+            ("poa_admin", current_config.poa_admin.as_str()),
+            ("rate", current_config.rate.to_string().as_str()),
+            ("source_denom", current_config.source_denom.as_str()),
+            ("target_denom", current_config.target_denom.as_str()),
+            ("paused", current_config.paused.to_string().as_str()),
+        ]))
     }
 
     // Convert source tokens to target tokens
@@ -134,8 +226,13 @@ mod exec {
     // 2. Send the source tokens to the POA admin address to be burned
     // 3. Calculate the amount of target tokens to mint based on the contract's rate
     // 4. Burn and mint tokens via AuthZ messages
-    pub fn convert(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+    pub fn convert(deps: Deps, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
         let config = CONFIG.load(deps.storage)?;
+
+        // Ensure contract is not paused
+        if config.paused {
+            return Err(ContractError::Paused);
+        }
 
         // Funds (info.funds) are processed by the Bank module before reaching the contract
         // Ensure exactly one coin is sent
@@ -144,6 +241,10 @@ mod exec {
         // The coin should be of the source_denom type
         if coin.denom != config.source_denom.to_string() {
             return Err(ContractError::ConvertError(InvalidSourceDenom));
+        }
+
+        if coin.amount.is_zero() {
+            return Err(ContractError::AmountError(AmountIsZero));
         }
 
         // Calculate amount to mint based on rate
@@ -193,32 +294,57 @@ mod exec {
         Ok(Response::new()
             .add_message(send)
             .add_message(msg)
-            .add_attribute("action", "convert")
-            .add_attribute("sender", info.sender.to_string())
-            .add_attribute("poa_admin", config.poa_admin.into_string())
-            .add_attribute("burned", coin.amount.to_string())
-            .add_attribute("minted", amt_to_mint.to_string())
-            .add_attribute("burned_denom", config.source_denom)
-            .add_attribute("minted_denom", config.target_denom))
+            .add_attributes([
+                ("action", "convert"),
+                ("contract", CONTRACT_NAME),
+                ("version", CONTRACT_VERSION),
+                ("sender", info.sender.as_str()),
+                ("poa_admin", config.poa_admin.as_str()),
+                ("burned", coin.amount.to_string().as_str()),
+                ("minted", amt_to_mint.to_string().as_str()),
+                ("burned_denom", config.source_denom.as_str()),
+                ("minted_denom", config.target_denom.as_str()),
+                ("authz_grantee", env.contract.address.as_str()),
+                ("authz_msg_count", "2"),
+                ("burn_type", MsgBurnHeldBalance::TYPE_URL),
+                ("mint_type", MsgMint::TYPE_URL),
+            ]))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::consts::{BECH32_PREFIX, DEFAULT_POA_ADMIN};
     use crate::denom::Denom;
-    use crate::msg::{ConfigResp, UpdateConfig};
+    use crate::msg::UpdateConfig;
     use crate::rate::Rate;
     use crate::state::Config;
-    use cosmwasm_std::{Addr, CustomMsg, Empty};
-    use cw_multi_test::{App, Contract, ContractWrapper, Executor};
+    use cosmwasm_std::testing::MockApi;
+    use cosmwasm_std::{Addr, Coin, CustomMsg, Empty};
+    use cw_multi_test::{App, AppBuilder, Contract, ContractWrapper, Executor, StargateAccepting};
 
     pub fn contract() -> Box<dyn Contract<Empty>> {
-        Box::new(ContractWrapper::new_with_empty(execute, instantiate, query))
+        Box::new(ContractWrapper::new_with_empty(execute, instantiate, query).with_migrate(migrate))
     }
 
-    fn setup_app() -> (App, u64) {
-        let mut app = App::default();
+    fn setup_default_app() -> (App, u64) {
+        let mut app = AppBuilder::default()
+            .with_api(MockApi::default().with_prefix(BECH32_PREFIX))
+            .build(|_, _, _| {});
+        let code_id = app.store_code(contract());
+        (app, code_id)
+    }
+
+    fn setup_app_with_funds(sender: &Addr, coin: Coin) -> (App, u64) {
+        let mut app = AppBuilder::default()
+            .with_api(MockApi::default().with_prefix(BECH32_PREFIX))
+            .build(|router, _, storage| {
+                router
+                    .bank
+                    .init_balance(storage, sender, vec![coin.clone()])
+                    .unwrap();
+            });
         let code_id = app.store_code(contract());
         (app, code_id)
     }
@@ -226,12 +352,20 @@ mod tests {
     fn instantiate_contract<T: CustomMsg + 'static, A: Executor<T>>(
         app: &mut A,
         code_id: u64,
+        admin: Addr,
         config: Config,
     ) -> StdResult<Addr> {
         app.instantiate_contract(
             code_id,
             Addr::unchecked("creator"),
-            &InstantiateMsg { config },
+            &InstantiateMsg {
+                admin: admin.to_string(),
+                poa_admin: config.poa_admin.to_string(),
+                rate: config.rate.to_string(),
+                source_denom: config.source_denom.to_string(),
+                target_denom: config.target_denom.to_string(),
+                paused: config.paused,
+            },
             &[],
             "test",
             None,
@@ -239,107 +373,116 @@ mod tests {
     }
 
     #[test]
-    fn init() {
-        let (mut app, code_id) = setup_app();
-        let config =
-            Config::with_defaults(app.api().addr_make("admin"), Rate::parse("42").unwrap());
-        let addr = instantiate_contract(&mut app, code_id, config.clone()).unwrap();
+    fn init() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let admin = app.api().addr_make("admin");
+        let config = Config::try_with_defaults(Rate::parse("42")?)?;
+        let addr = instantiate_contract(&mut app, code_id, admin, config.clone())?;
 
-        let resp: ConfigResp = app
-            .wrap()
-            .query_wasm_smart(&addr, &QueryMsg::Config {})
-            .unwrap();
-        assert_eq!(resp.config.rate, config.rate);
-        assert_eq!(resp.config.admin.to_string(), config.admin.to_string());
+        let resp: Config = app.wrap().query_wasm_smart(&addr, &QueryMsg::Config {})?;
+        assert_eq!(resp.rate, config.rate);
+        assert_eq!(resp.poa_admin.as_str(), DEFAULT_POA_ADMIN);
+
+        Ok(())
     }
 
     #[test]
-    fn init_invalid_admin() {
-        let (mut app, code_id) = setup_app();
-        let config = Config::with_defaults(Addr::unchecked("invalid"), Rate::parse("42").unwrap());
-        let err = instantiate_contract(&mut app, code_id, config).unwrap_err();
+    fn init_invalid_admin() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let admin = Addr::unchecked("invalid");
+        let config = Config::try_with_defaults(Rate::parse("42")?)?;
+        let err = instantiate_contract(&mut app, code_id, admin, config).unwrap_err();
         assert!(err.to_string().contains("parse failed"));
+        Ok(())
     }
 
     #[test]
-    fn init_invalid_rate() {
-        let (mut app, code_id) = setup_app();
-        let config = Config::with_defaults(
-            app.api().addr_make("admin"),
-            Rate::parse_unchecked("0").unwrap(),
-        );
-        let err = instantiate_contract(&mut app, code_id, config).unwrap_err();
+    fn init_invalid_rate() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let admin = app.api().addr_make("admin");
+        let config = Config::try_with_defaults(Rate::parse_unchecked("0")?)?;
+        let err = instantiate_contract(&mut app, code_id, admin, config).unwrap_err();
         assert!(err.to_string().contains("invalid rate"));
         assert!(err.to_string().contains("rate is zero"));
+        Ok(())
     }
 
     #[test]
-    fn update_config() {
-        let (mut app, code_id) = setup_app();
-        let config =
-            Config::with_defaults(app.api().addr_make("admin"), Rate::parse("42").unwrap());
-        let addr = instantiate_contract(&mut app, code_id, config.clone()).unwrap();
+    fn init_same_denom() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let admin = app.api().addr_make("admin");
+        let mut config = Config::try_with_defaults(Rate::parse("42")?)?;
+        config.target_denom = config.source_denom.clone();
+        let err = instantiate_contract(&mut app, code_id, admin, config).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("source and target denom cannot be the same"));
+        Ok(())
+    }
 
-        let new_admin = app.api().addr_make("new_admin");
+    #[test]
+    fn update_config() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let admin = app.api().addr_make("admin");
+        let config = Config::try_with_defaults(Rate::parse("42")?)?;
+        let addr = instantiate_contract(&mut app, code_id, admin.clone(), config.clone())?;
+
         let new_poa_admin = app.api().addr_make("new_poa_admin");
         let new_rate = "100".to_string();
         let new_source = "umfx".to_string();
         let new_target = "uatom".to_string();
         let update_msg = ExecuteMsg::UpdateConfig {
             config: UpdateConfig {
-                admin: Some(new_admin.to_string()),
                 poa_admin: Some(new_poa_admin.to_string()),
                 rate: Some(new_rate.clone()),
                 source_denom: Some(new_source.clone()),
                 target_denom: Some(new_target.clone()),
+                paused: Some(false),
             },
         };
-        let res = app.execute_contract(config.admin, addr.clone(), &update_msg, &[]);
+        let res = app.execute_contract(admin, addr.clone(), &update_msg, &[]);
         assert!(res.is_ok());
 
-        let resp: ConfigResp = app
-            .wrap()
-            .query_wasm_smart(&addr, &QueryMsg::Config {})
-            .unwrap();
-        assert_eq!(resp.config.rate, Rate::parse(&new_rate).unwrap());
-        assert_eq!(resp.config.admin.to_string(), new_admin.to_string());
-        assert_eq!(resp.config.poa_admin.to_string(), new_poa_admin.to_string());
-        assert_eq!(resp.config.source_denom, Denom::unchecked(new_source));
-        assert_eq!(resp.config.target_denom, Denom::unchecked(new_target));
+        let resp: Config = app.wrap().query_wasm_smart(&addr, &QueryMsg::Config {})?;
+        assert_eq!(resp.rate, Rate::parse(&new_rate)?);
+        assert_eq!(resp.poa_admin.to_string(), new_poa_admin.to_string());
+        assert_eq!(resp.source_denom, Denom::unchecked(new_source));
+        assert_eq!(resp.target_denom, Denom::unchecked(new_target));
+        Ok(())
     }
 
     #[test]
-    fn update_config_unauthorized() {
-        let (mut app, code_id) = setup_app();
-        let config =
-            Config::with_defaults(app.api().addr_make("admin"), Rate::parse("42").unwrap());
-        let addr = instantiate_contract(&mut app, code_id, config).unwrap();
+    fn update_config_unauthorized() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let admin = app.api().addr_make("admin");
+        let config = Config::try_with_defaults(Rate::parse("42")?)?;
+        let addr = instantiate_contract(&mut app, code_id, admin, config)?;
 
         let unauthorized = app.api().addr_make("unauthorized");
-        let new_admin = app.api().addr_make("new_admin");
         let update_msg = ExecuteMsg::UpdateConfig {
             config: UpdateConfig {
-                admin: Some(new_admin.to_string()),
+                paused: Some(false),
                 ..Default::default()
             },
         };
         let res = app.execute_contract(unauthorized.clone(), addr.clone(), &update_msg, &[]);
         assert!(res.is_err());
         let err = res.unwrap_err();
+        dbg!(&err);
         assert!(err.to_string().contains("unauthorized"));
         assert!(err
             .to_string()
             .contains("only admin can perform this action"));
+        Ok(())
     }
 
     #[test]
-    fn update_config_invalid_rate() {
-        let (mut app, code_id) = setup_app();
-        let config =
-            Config::with_defaults(app.api().addr_make("admin"), Rate::parse("42").unwrap());
+    fn update_config_invalid_rate() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let config = Config::try_with_defaults(Rate::parse("42")?)?;
         let admin = app.api().addr_make("admin");
 
-        let addr = instantiate_contract(&mut app, code_id, config).unwrap();
+        let addr = instantiate_contract(&mut app, code_id, admin.clone(), config)?;
 
         let update_msg = ExecuteMsg::UpdateConfig {
             config: UpdateConfig {
@@ -348,37 +491,19 @@ mod tests {
             },
         };
         let err = app
-            .execute_contract(admin.clone(), addr.clone(), &update_msg, &[])
+            .execute_contract(admin, addr.clone(), &update_msg, &[])
             .unwrap_err();
         assert!(err.to_string().contains("invalid rate"));
         assert!(err.to_string().contains("rate is zero"));
+        Ok(())
     }
 
     #[test]
-    fn update_config_invalid_admin() {
-        let (mut app, code_id) = setup_app();
-        let config =
-            Config::with_defaults(app.api().addr_make("admin"), Rate::parse("42").unwrap());
-        let addr = instantiate_contract(&mut app, code_id, config.clone()).unwrap();
-
-        let update_msg = ExecuteMsg::UpdateConfig {
-            config: UpdateConfig {
-                admin: Some("invalid_admin".to_string()),
-                ..Default::default()
-            },
-        };
-        let err = app
-            .execute_contract(config.admin, addr.clone(), &update_msg, &[])
-            .unwrap_err();
-        assert!(err.to_string().contains("parse failed"));
-    }
-
-    #[test]
-    fn update_config_empty_source_denom() {
-        let (mut app, code_id) = setup_app();
-        let config =
-            Config::with_defaults(app.api().addr_make("admin"), Rate::parse("42").unwrap());
-        let addr = instantiate_contract(&mut app, code_id, config.clone()).unwrap();
+    fn update_config_empty_source_denom() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let admin = app.api().addr_make("admin");
+        let config = Config::try_with_defaults(Rate::parse("42")?)?;
+        let addr = instantiate_contract(&mut app, code_id, admin.clone(), config.clone())?;
 
         let update_msg = ExecuteMsg::UpdateConfig {
             config: UpdateConfig {
@@ -387,18 +512,19 @@ mod tests {
             },
         };
         let err = app
-            .execute_contract(config.admin.clone(), addr.clone(), &update_msg, &[])
+            .execute_contract(admin, addr, &update_msg, &[])
             .unwrap_err();
         assert!(err.to_string().contains("invalid denom"));
         assert!(err.to_string().contains("denom is empty"));
+        Ok(())
     }
 
     #[test]
-    fn update_config_empty_target_denom() {
-        let (mut app, code_id) = setup_app();
-        let config =
-            Config::with_defaults(app.api().addr_make("admin"), Rate::parse("42").unwrap());
-        let addr = instantiate_contract(&mut app, code_id, config.clone()).unwrap();
+    fn update_config_empty_target_denom() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let admin = app.api().addr_make("admin");
+        let config = Config::try_with_defaults(Rate::parse("42")?)?;
+        let addr = instantiate_contract(&mut app, code_id, admin.clone(), config.clone())?;
 
         let update_msg = ExecuteMsg::UpdateConfig {
             config: UpdateConfig {
@@ -407,18 +533,19 @@ mod tests {
             },
         };
         let err = app
-            .execute_contract(config.admin.clone(), addr.clone(), &update_msg, &[])
+            .execute_contract(admin, addr, &update_msg, &[])
             .unwrap_err();
         assert!(err.to_string().contains("invalid denom"));
         assert!(err.to_string().contains("denom is empty"));
+        Ok(())
     }
 
     #[test]
-    fn update_config_partial() {
-        let (mut app, code_id) = setup_app();
-        let config =
-            Config::with_defaults(app.api().addr_make("admin"), Rate::parse("42").unwrap());
-        let addr = instantiate_contract(&mut app, code_id, config.clone()).unwrap();
+    fn update_config_partial() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let admin = app.api().addr_make("admin");
+        let config = Config::try_with_defaults(Rate::parse("42")?)?;
+        let addr = instantiate_contract(&mut app, code_id, admin.clone(), config.clone())?;
 
         let new_rate = "100".to_string();
         let update_msg = ExecuteMsg::UpdateConfig {
@@ -427,46 +554,100 @@ mod tests {
                 ..Default::default()
             },
         };
-        let res = app.execute_contract(config.admin.clone(), addr.clone(), &update_msg, &[]);
+        let res = app.execute_contract(admin.clone(), addr.clone(), &update_msg, &[]);
         assert!(res.is_ok());
 
-        let resp: ConfigResp = app
-            .wrap()
-            .query_wasm_smart(&addr, &QueryMsg::Config {})
-            .unwrap();
-        assert_eq!(resp.config.rate, Rate::parse(&new_rate).unwrap());
-        assert_eq!(resp.config.admin.to_string(), config.admin.to_string());
+        let resp: Config = app.wrap().query_wasm_smart(&addr, &QueryMsg::Config {})?;
+        assert_eq!(resp.rate, Rate::parse(&new_rate)?);
+        assert_eq!(resp.poa_admin.to_string(), config.poa_admin.to_string());
+        Ok(())
     }
 
     #[test]
-    fn no_update_config() {
-        let (mut app, code_id) = setup_app();
-        let config =
-            Config::with_defaults(app.api().addr_make("admin"), Rate::parse("42").unwrap());
-        let addr = instantiate_contract(&mut app, code_id, config.clone()).unwrap();
+    fn no_update_config() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let admin = app.api().addr_make("admin");
+        let config = Config::try_with_defaults(Rate::parse("42")?)?;
+        let addr = instantiate_contract(&mut app, code_id, admin.clone(), config.clone())?;
 
         let update_msg = ExecuteMsg::UpdateConfig {
             config: UpdateConfig {
                 ..Default::default()
             },
         };
-        let res = app.execute_contract(config.admin.clone(), addr.clone(), &update_msg, &[]);
+        let res = app.execute_contract(admin, addr.clone(), &update_msg, &[]);
         assert!(res.is_ok());
 
-        let resp: ConfigResp = app
-            .wrap()
-            .query_wasm_smart(&addr, &QueryMsg::Config {})
+        let resp: Config = app.wrap().query_wasm_smart(&addr, &QueryMsg::Config {})?;
+        assert_eq!(resp.rate, config.rate);
+        assert_eq!(resp.poa_admin.to_string(), config.poa_admin.to_string());
+
+        let app_response = res?;
+        let ev = app_response
+            .events
+            .iter()
+            .find(|ev| ev.ty == "wasm")
             .unwrap();
-        assert_eq!(resp.config.rate, config.rate);
-        assert_eq!(resp.config.admin.to_string(), config.admin.to_string());
+        assert_eq!(
+            ev.attributes
+                .iter()
+                .find(|attr| attr.key == "note")
+                .unwrap()
+                .value,
+            "empty config, no changes made"
+        );
+        Ok(())
     }
 
     #[test]
-    fn convert_no_fund() {
-        let (mut app, code_id) = setup_app();
-        let config =
-            Config::with_defaults(app.api().addr_make("admin"), Rate::parse("42").unwrap());
-        let addr = instantiate_contract(&mut app, code_id, config.clone()).unwrap();
+    fn noop_update_config() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let admin = app.api().addr_make("admin");
+        let config = Config::try_with_defaults(Rate::parse("42")?)?;
+        let addr = instantiate_contract(&mut app, code_id, admin.clone(), config.clone())?;
+
+        let update_msg = ExecuteMsg::UpdateConfig {
+            config: UpdateConfig {
+                poa_admin: Some(config.poa_admin.to_string()),
+                rate: Some(config.rate.to_string()),
+                source_denom: Some(config.source_denom.to_string()),
+                target_denom: Some(config.target_denom.to_string()),
+                paused: Some(config.paused),
+            },
+        };
+        let res = app.execute_contract(admin, addr.clone(), &update_msg, &[]);
+        assert!(res.is_ok());
+
+        let resp: Config = app.wrap().query_wasm_smart(&addr, &QueryMsg::Config {})?;
+        assert_eq!(resp.rate, config.rate);
+        assert_eq!(resp.poa_admin.to_string(), config.poa_admin.to_string());
+        assert_eq!(resp.source_denom, config.source_denom);
+        assert_eq!(resp.target_denom, config.target_denom);
+        assert_eq!(resp.paused, config.paused);
+
+        let app_response = res?;
+        let ev = app_response
+            .events
+            .iter()
+            .find(|ev| ev.ty == "wasm")
+            .unwrap();
+        assert_eq!(
+            ev.attributes
+                .iter()
+                .find(|attr| attr.key == "note")
+                .unwrap()
+                .value,
+            "identical config, no changes made"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn convert_no_fund() -> Result<(), ContractError> {
+        let (mut app, code_id) = setup_default_app();
+        let admin = app.api().addr_make("admin");
+        let config = Config::try_with_defaults(Rate::parse("42")?)?;
+        let addr = instantiate_contract(&mut app, code_id, admin, config.clone())?;
 
         let sender = app.api().addr_make("sender");
         let convert_msg = ExecuteMsg::Convert {};
@@ -474,32 +655,24 @@ mod tests {
             .execute_contract(sender, addr.clone(), &convert_msg, &[])
             .unwrap_err();
         assert!(err.to_string().contains("invalid funds sent"));
+        Ok(())
     }
 
     #[test]
-    fn convert_invalid_source_denom() {
+    fn convert_invalid_source_denom() -> Result<(), ContractError> {
         let sender = Addr::unchecked("sender");
-        let mut app = App::new(|router, _, storage| {
-            router
-                .bank
-                .init_balance(
-                    storage,
-                    &sender,
-                    vec![cosmwasm_std::Coin {
-                        denom: "invalid".to_string(),
-                        amount: cosmwasm_std::Uint256::new(100),
-                    }],
-                )
-                .unwrap();
-        });
-        let code_id = app.store_code(contract());
+        let coin = Coin {
+            denom: "invalid".to_string(),
+            amount: cosmwasm_std::Uint256::new(100),
+        };
 
-        let config =
-            Config::with_defaults(app.api().addr_make("admin"), Rate::parse("42").unwrap());
-        let addr = instantiate_contract(&mut app, code_id, config.clone()).unwrap();
+        let (mut app, code_id) = setup_app_with_funds(&sender, coin.clone());
+        let admin = app.api().addr_make("admin");
+        let config = Config::try_with_defaults(Rate::parse("42")?)?;
+        let addr = instantiate_contract(&mut app, code_id, admin, config.clone())?;
 
         let convert_msg = ExecuteMsg::Convert {};
-        let funds = vec![cosmwasm_std::Coin {
+        let funds = vec![Coin {
             denom: "invalid".to_string(),
             amount: cosmwasm_std::Uint256::new(100),
         }];
@@ -507,5 +680,81 @@ mod tests {
             .execute_contract(sender, addr.clone(), &convert_msg, &funds)
             .unwrap_err();
         assert!(err.to_string().contains("invalid source denom"));
+        Ok(())
+    }
+
+    #[test]
+    fn paused() -> Result<(), ContractError> {
+        let sender = Addr::unchecked("sender");
+        let coin = Coin {
+            denom: "umfx".to_string(),
+            amount: cosmwasm_std::Uint256::new(100),
+        };
+
+        let (mut app, code_id) = setup_app_with_funds(&sender, coin.clone());
+        let admin = app.api().addr_make("admin");
+        let mut config = Config::try_with_defaults(Rate::parse("42")?)?;
+        config.paused = true;
+        let addr = instantiate_contract(&mut app, code_id, admin, config.clone())?;
+
+        let convert_msg = ExecuteMsg::Convert {};
+        let funds = vec![Coin {
+            denom: "umfx".to_string(),
+            amount: cosmwasm_std::Uint256::new(100),
+        }];
+        let err = app
+            .execute_contract(sender, addr.clone(), &convert_msg, &funds)
+            .unwrap_err();
+        assert!(err.to_string().contains("contract is paused"));
+        Ok(())
+    }
+
+    #[test]
+    fn paused_unpaused() -> Result<(), ContractError> {
+        let sender = Addr::unchecked("sender");
+        let coin = Coin {
+            denom: "umfx".to_string(),
+            amount: cosmwasm_std::Uint256::new(100),
+        };
+
+        let mut app = AppBuilder::default()
+            .with_stargate(StargateAccepting) // Needed for AnyMsg, otherwise we get `Unexpected any execute: msg=AnyMsg`
+            .with_api(MockApi::default().with_prefix(BECH32_PREFIX))
+            .build(|router, _, storage| {
+                router
+                    .bank
+                    .init_balance(storage, &sender, vec![coin.clone()])
+                    .unwrap();
+            });
+        let code_id = app.store_code(contract());
+        let admin = app.api().addr_make("admin");
+        let mut config = Config::try_with_defaults(Rate::parse("42")?)?;
+        config.paused = true;
+        let addr = instantiate_contract(&mut app, code_id, admin.clone(), config.clone())?;
+
+        let convert_msg = ExecuteMsg::Convert {};
+        let funds = vec![Coin {
+            denom: "umfx".to_string(),
+            amount: cosmwasm_std::Uint256::new(100),
+        }];
+        let err = app
+            .execute_contract(sender.clone(), addr.clone(), &convert_msg, &funds)
+            .unwrap_err();
+        assert!(err.to_string().contains("contract is paused"));
+
+        // Unpause the contract
+        let update_msg = ExecuteMsg::UpdateConfig {
+            config: UpdateConfig {
+                paused: Some(false),
+                ..Default::default()
+            },
+        };
+        let res = app.execute_contract(admin, addr.clone(), &update_msg, &[]);
+        assert!(res.is_ok());
+
+        // Try converting again
+        let res = app.execute_contract(sender.clone(), addr.clone(), &convert_msg, &funds);
+        assert!(res.is_ok());
+        Ok(())
     }
 }

--- a/converter/src/error.rs
+++ b/converter/src/error.rs
@@ -6,7 +6,7 @@ pub enum ContractError {
     #[error("{0}")]
     StdError(#[from] StdError),
     #[error("unauthorized: {0}")]
-    Unauthorized(#[from] AuthError),
+    AdminError(#[from] AdminError),
     #[error("invalid rate: {0}")]
     RateError(#[from] RateError),
     #[error("invalid denom: {0}")]
@@ -68,9 +68,11 @@ pub enum DenomError {
 }
 
 #[derive(Error, Debug)]
-pub enum AuthError {
+pub enum AdminError {
     #[error("only admin can perform this action")]
     NotAdmin,
+    #[error("cannot renounce admin role")]
+    CannotRenounce,
 }
 
 #[derive(Error, Debug)]

--- a/converter/src/error.rs
+++ b/converter/src/error.rs
@@ -17,6 +17,10 @@ pub enum ContractError {
     ConvertError(#[from] ConvertError),
     #[error("configuration error: {0}")]
     ConfigError(#[from] ConfigError),
+    #[error("migration error: {0}")]
+    MigrateError(#[from] MigrateError),
+    #[error("contract is paused")]
+    Paused,
 }
 
 #[derive(Error, Debug)]
@@ -39,6 +43,8 @@ pub enum AmountError {
     AmountExceedsMax,
     #[error("failed to parse amount")]
     InvalidAmountParsing,
+    #[error("non-payable function called with funds")]
+    NonPayable,
 }
 
 #[derive(Error, Debug)]
@@ -71,4 +77,10 @@ pub enum AuthError {
 pub enum ConfigError {
     #[error("source and target denom cannot be the same")]
     SameDenom,
+}
+
+#[derive(Error, Debug)]
+pub enum MigrateError {
+    #[error("invalid contract name")]
+    InvalidContractName,
 }

--- a/converter/src/lib.rs
+++ b/converter/src/lib.rs
@@ -1,6 +1,8 @@
 use crate::error::ContractError;
-use crate::msg::{ExecuteMsg, InstantiateMsg};
-use cosmwasm_std::{entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg};
+use cosmwasm_std::{
+    entry_point, Binary, Deps, DepsMut, Env, MessageInfo, MigrateInfo, Response, StdResult,
+};
 
 mod consts;
 mod contract;
@@ -33,4 +35,14 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     contract::execute(deps, env, info, msg)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(
+    deps: DepsMut,
+    env: Env,
+    msg: MigrateMsg,
+    info: MigrateInfo,
+) -> Result<Response, ContractError> {
+    contract::migrate(deps, env, msg, info)
 }

--- a/converter/src/msg.rs
+++ b/converter/src/msg.rs
@@ -3,26 +3,34 @@ use cosmwasm_schema::cw_serde;
 
 #[cw_serde]
 pub struct InstantiateMsg {
-    pub config: Config,
+    pub admin: String,
+    pub poa_admin: String,
+    pub rate: String,
+    pub source_denom: String,
+    pub target_denom: String,
+    pub paused: bool,
 }
 
 #[cw_serde]
 pub enum ExecuteMsg {
     Convert {},
     UpdateConfig { config: UpdateConfig },
+    UpdateAdmin { admin: Option<String> },
 }
 
 #[cw_serde]
 pub enum QueryMsg {
     Config {},
+    Admin {},
 }
+
+#[cw_serde]
+pub enum MigrateMsg {}
 
 // TODO: Write a macro to generate this struct from the Config struct
 #[cw_serde]
 #[derive(Default)]
 pub struct UpdateConfig {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub admin: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub poa_admin: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -31,18 +39,46 @@ pub struct UpdateConfig {
     pub source_denom: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_denom: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paused: Option<bool>,
 }
 
 impl UpdateConfig {
+    // Check if no fields are set in this update
     pub fn is_empty(&self) -> bool {
-        self.admin.is_none()
+        self.poa_admin.is_none()
             && self.rate.is_none()
             && self.source_denom.is_none()
             && self.target_denom.is_none()
+            && self.paused.is_none()
     }
-}
 
-#[cw_serde]
-pub struct ConfigResp {
-    pub config: Config,
+    // Check if applying this update to the given config would result in no changes
+    pub fn is_noop(&self, other: &Config) -> bool {
+        (self.poa_admin.is_none()
+            || self
+                .poa_admin
+                .as_ref()
+                .map(|a| a == other.poa_admin.as_str())
+                .unwrap_or(true))
+            && (self.rate.is_none()
+                || self
+                    .rate
+                    .as_ref()
+                    .map(|r| r == &other.rate.as_ref().to_string())
+                    .unwrap_or(true))
+            && (self.source_denom.is_none()
+                || self
+                    .source_denom
+                    .as_ref()
+                    .map(|d| d == other.source_denom.as_str())
+                    .unwrap_or(true))
+            && (self.target_denom.is_none()
+                || self
+                    .target_denom
+                    .as_ref()
+                    .map(|d| d == other.target_denom.as_str())
+                    .unwrap_or(true))
+            && (self.paused.is_none() || self.paused.map(|p| p == other.paused).unwrap_or(true))
+    }
 }

--- a/converter/src/state.rs
+++ b/converter/src/state.rs
@@ -44,4 +44,11 @@ impl Config {
             paused: false,
         })
     }
+
+    pub fn validate(&self) -> Result<(), ContractError> {
+        if self.source_denom == self.target_denom {
+            return Err(ContractError::ConfigError(SameDenom));
+        }
+        Ok(())
+    }
 }

--- a/converter/src/state.rs
+++ b/converter/src/state.rs
@@ -25,7 +25,7 @@ pub struct Config {
     // If non-optional fields are added, config must be versioned and the migration handler must be updated
 }
 
-// Never rename this key the storage keys
+// Never rename the storage keys
 pub const CONFIG: Item<Config> = Item::new("config");
 pub const ADMIN: Admin = Admin::new("admin");
 

--- a/converter/src/state.rs
+++ b/converter/src/state.rs
@@ -1,30 +1,47 @@
 use crate::consts::{default_source_denom, default_target_denom, DEFAULT_POA_ADMIN};
 use crate::denom::Denom;
+use crate::error::ConfigError::SameDenom;
+use crate::error::ContractError;
 use crate::rate::Rate;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Addr;
+use cw_controllers::Admin;
 use cw_storage_plus::Item;
 
+// Never rename/remove fields from this struct, only add optional fields to avoid
+// breaking changes. If you need to rename/remove a field, you must version the config
 #[cw_serde]
 pub struct Config {
-    pub admin: Addr,
     pub poa_admin: Addr,
     pub rate: Rate,
     pub source_denom: Denom,
     pub target_denom: Denom,
+    pub paused: bool,
+    // Future fields should be optional, e.g.
+    //
+    //   #[serde(default, skip_serializing_if = "Option::is_none")]
+    //   pub min_amount: Option<Uint256>,
+    //
+    // If non-optional fields are added, config must be versioned and the migration handler must be updated
 }
 
+// Never rename this key the storage keys
 pub const CONFIG: Item<Config> = Item::new("config");
+pub const ADMIN: Admin = Admin::new("admin");
 
 impl Config {
-    pub fn with_defaults(admin: Addr, rate: Rate) -> Self {
-        assert_ne!(default_target_denom(), default_source_denom());
-        Self {
-            admin,
+    pub fn try_with_defaults(rate: Rate) -> Result<Self, ContractError> {
+        let s = default_source_denom();
+        let t = default_target_denom();
+        if s == t {
+            return Err(ContractError::ConfigError(SameDenom));
+        }
+        Ok(Self {
             poa_admin: Addr::unchecked(DEFAULT_POA_ADMIN),
             rate,
-            source_denom: default_source_denom(),
-            target_denom: default_target_denom(),
-        }
+            source_denom: s,
+            target_denom: t,
+            paused: false,
+        })
     }
 }


### PR DESCRIPTION
This pull request introduces several significant enhancements and refactors to the converter contract, primarily focused on improving admin and contract management, error handling, and configurability. The changes include adopting the `cw-controllers` admin pattern, adding contract migration support, expanding configuration options (including pausing the contract), and refactoring error types for clarity and extensibility.

**Admin and Contract Management:**
- Switched to using the `cw-controllers` crate for admin management, replacing the previous custom admin logic. This introduces a new `Admin` controller and updates relevant error types and messages. [[1]](diffhunk://#diff-877e86932363a03edbbcbc8c952ea9396ba16a14e508bfe2ae5393e3ea5348c7R17-R18) [[2]](diffhunk://#diff-a9bb11c6a1a0b520349e3287b7b2a11051000305a6a3407257d4bc6c21b39463L65-R88) [[3]](diffhunk://#diff-73ae001374462f92a49d80fa345f89852e1fc98a8d42e5148c0cb614be20275aR3-R52)
- Added new `UpdateAdmin` execute message and `Admin` query message for improved admin management.

**Contract Migration and Versioning:**
- Implemented a migration entry point and message, enabling future contract upgrades and safe state migrations. [[1]](diffhunk://#diff-75696bc321697109f67ef450b57d958737400ca0b314fb9e487d53cafc0097faL2-R5) [[2]](diffhunk://#diff-75696bc321697109f67ef450b57d958737400ca0b314fb9e487d53cafc0097faR39-R48) [[3]](diffhunk://#diff-d62e0a70fbd411d86f0bbb038c5bd42059564eac2e3815a1d9eda6038d9ebe9eL6-L25)
- Introduced contract name and version constants for migration/version checks.

**Configuration and State Improvements:**
- Refactored the `Config` struct to add a `paused` field and updated the `InstantiateMsg` and `UpdateConfig` types to support new fields and validation logic. [[1]](diffhunk://#diff-d62e0a70fbd411d86f0bbb038c5bd42059564eac2e3815a1d9eda6038d9ebe9eL6-L25) [[2]](diffhunk://#diff-d62e0a70fbd411d86f0bbb038c5bd42059564eac2e3815a1d9eda6038d9ebe9eR42-R83) [[3]](diffhunk://#diff-73ae001374462f92a49d80fa345f89852e1fc98a8d42e5148c0cb614be20275aR3-R52)
- Added methods for checking if an update is a no-op and for validating config state. [[1]](diffhunk://#diff-d62e0a70fbd411d86f0bbb038c5bd42059564eac2e3815a1d9eda6038d9ebe9eR42-R83) [[2]](diffhunk://#diff-73ae001374462f92a49d80fa345f89852e1fc98a8d42e5148c0cb614be20275aR3-R52)

**Error Handling Enhancements:**
- Renamed `AuthError` to `AdminError` and expanded error enums to cover new cases, such as migration errors, paused contract state, and non-payable function calls. [[1]](diffhunk://#diff-a9bb11c6a1a0b520349e3287b7b2a11051000305a6a3407257d4bc6c21b39463L9-R9) [[2]](diffhunk://#diff-a9bb11c6a1a0b520349e3287b7b2a11051000305a6a3407257d4bc6c21b39463R20-R23) [[3]](diffhunk://#diff-a9bb11c6a1a0b520349e3287b7b2a11051000305a6a3407257d4bc6c21b39463R46-R47) [[4]](diffhunk://#diff-a9bb11c6a1a0b520349e3287b7b2a11051000305a6a3407257d4bc6c21b39463L65-R88)

**Miscellaneous:**
- Updated the default POA admin address to use a configurable Bech32 prefix.

These changes collectively make the contract more robust, flexible, and maintainable, while laying the groundwork for future upgrades and feature additions.