### PR TITLE
ci: protoc and codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,9 @@ jobs:
             sudo apt-get install -y protobuf-compiler
             protoc --version
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+        run: cargo +1.82.0 install cargo-tarpaulin
       - name: Run coverage
-        run: cargo tarpaulin --workspace --all-features --all-targets --locked --out Xml --output-dir coverage
+        run: cargo +1.82.0 tarpaulin --workspace --all-features --all-targets --locked --out Xml --output-dir coverage
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt, clippy
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          protoc --version
       - name: rustfmt check
         run: cargo fmt --all -- --check
       - name: clippy check
@@ -37,6 +42,11 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: wasm32-unknown-unknown
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          protoc --version
       - name: Cargo fetch
         run: cargo fetch --locked
       - name: Build (all targets)
@@ -51,3 +61,30 @@ jobs:
         with:
             name: converter-wasm
             path: target/wasm32-unknown-unknown/release/*.wasm
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: fmt_lint
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: wasm32-unknown-unknown
+      - name: Install protoc
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y protobuf-compiler
+            protoc --version
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Run coverage
+        run: cargo tarpaulin --workspace --all-features --all-targets --locked --out Xml --output-dir coverage
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/cobertura.xml
+          fail_ci_if_error: true


### PR DESCRIPTION
This pull request updates the CI workflow configuration in `.github/workflows/ci.yml` to improve build reliability and add automated test coverage reporting. The most important changes include installing the `protoc` compiler in multiple CI jobs and introducing a new coverage job that runs code coverage analysis and uploads reports to Codecov.

**CI Environment Improvements:**

* Added installation steps for the `protobuf-compiler` (`protoc`) in both the formatting/linting and build jobs to ensure protocol buffer support is available during CI runs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR24-R28) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR45-R49)

**Test Coverage Automation:**

* Introduced a new `coverage` job that installs the required toolchain and `protoc`, runs code coverage analysis using `cargo-tarpaulin`, and uploads the results to Codecov for better visibility into test coverage.