### PR TITLE
ci: release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           tag_name: ${{ github.ref_name }}
           target_commitish: ${{ github.sha }}
           generate_release_notes: true
-          files:
+          files: |
            artifacts/*.wasm
            artifacts/checksums.txt
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release Wasm
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag (e.g., v1.2.3)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_VERSION: 1.81.0
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Rust (stable) + wasm target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: wasm32-unknown-unknown
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          protoc --version
+      - name: Install wasm-opt
+        run: cargo install wasm-opt --locked
+      - name: WASM release build
+        run: RUSTFLAGS="-C link-arg=-s" cargo wasm --locked
+      - name: Optimize WASM artifacts
+        run: |
+          mkdir artifacts
+          for f in target/wasm32-unknown-unknown/release/*.wasm; do
+              wasm-opt -Os "$f" -o "artifacts/$(basename "$f")"
+          done
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum -- *.wasm | tee checksums.txt
+      - name: Create GitHub Release and upload assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true
+          files:
+           artifacts/*.wasm
+           artifacts/checksums.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating the build and release process of WebAssembly (WASM) artifacts. The workflow handles building, optimizing, and publishing WASM binaries and their checksums when a release tag is pushed or manually triggered.

Release workflow automation:

* Added `.github/workflows/release.yml` to automate building, optimizing, and releasing WASM artifacts, including generating checksums and uploading assets to GitHub Releases.
* Configured the workflow to trigger on pushes to tags matching `v*` and via manual dispatch with a specified tag.
* Set up Rust toolchain and WASM target, installed necessary dependencies (`protobuf-compiler` and `wasm-opt`), and optimized WASM binaries using `wasm-opt`.
* Automatically generates SHA256 checksums for the released WASM files and includes them in the release.
* Uses `softprops/action-gh-release` to create a GitHub release and upload the WASM artifacts and checksums.